### PR TITLE
This pull fixes the text node drifting problem cause by text shake

### DIFF
--- a/printer/printer.lua
+++ b/printer/printer.lua
@@ -137,12 +137,7 @@ local function get_style(self, name)
 end
 
 
-local function set_shake(self, power, time)
-	-- Only update original position when not already shaking
-    if self.shake_time <= 0 then
-        self.node_parent_pos = gui.get_position(self.node_parent)
-    end
-	
+local function set_shake(self, power, time)	
 	self.shake_time = time
 	self.shake_power = power
 end
@@ -480,7 +475,6 @@ function M.print(self, str, source)
         self.node_parent_pos = gui.get_position(self.node_parent)
     end
 
-	-- self.node_parent_pos = gui.get_position(self.node_parent)
 	self.parent_size = gui.get_size(self.node_parent)
 
 	if self.is_print then
@@ -525,7 +519,6 @@ function M.update(self, dt)
         self.node_parent_pos = gui.get_position(self.node_parent)
     end
 
-	-- self.node_parent_pos = gui.get_position(self.node_parent)
 	self.parent_size = gui.get_size(self.node_parent)
 
 	if self.is_print then

--- a/printer/printer.lua
+++ b/printer/printer.lua
@@ -138,6 +138,11 @@ end
 
 
 local function set_shake(self, power, time)
+	-- Only update original position when not already shaking
+    if self.shake_time <= 0 then
+        self.node_parent_pos = gui.get_position(self.node_parent)
+    end
+	
 	self.shake_time = time
 	self.shake_power = power
 end
@@ -470,7 +475,12 @@ end
 
 
 function M.print(self, str, source)
-	self.node_parent_pos = gui.get_position(self.node_parent)
+	-- Only update node_parent_pos if we're not currently shaking
+    if self.shake_time <= 0 then
+        self.node_parent_pos = gui.get_position(self.node_parent)
+    end
+
+	-- self.node_parent_pos = gui.get_position(self.node_parent)
 	self.parent_size = gui.get_size(self.node_parent)
 
 	if self.is_print then
@@ -510,7 +520,12 @@ end
 
 
 function M.update(self, dt)
-	self.node_parent_pos = gui.get_position(self.node_parent)
+	-- Only update node_parent_pos if we're not currently shaking
+    if self.shake_time <= 0 then
+        self.node_parent_pos = gui.get_position(self.node_parent)
+    end
+
+	-- self.node_parent_pos = gui.get_position(self.node_parent)
 	self.parent_size = gui.get_size(self.node_parent)
 
 	if self.is_print then


### PR DESCRIPTION
The problem was that ``self.node_parent_pos`` was being updated in the ``update()`` function every frame. This was causing it to get the text nodes position during shake, thus losing the original position.

Even in the example, this is observed. The example starts off with the text node position as follows:

![dmengine_492hkERI74](https://github.com/user-attachments/assets/c760a7c3-13d8-4a68-8ef5-e0fe248a8e25)

But after a few runs, the text node drifts to the following position:

![dmengine_yJM3ltfxCc](https://github.com/user-attachments/assets/739bfcc2-9675-4006-9ba3-65bfe74f3394)

In my game, this causes the following problem:

![dmengine_pWJogY3SR9](https://github.com/user-attachments/assets/6d9d23ff-37c9-43d7-b6d3-c41714b2d4fe)


I added an if condition to fix this and now we get the position only after the ``self.shake_time <= 0``, effectively fixing the drifting problem

```lua
-- Only update node_parent_pos if we're not currently shaking
    if self.shake_time <= 0 then
        self.node_parent_pos = gui.get_position(self.node_parent)
    end
```

This fixes the problem and no matter how strong the shake, we dont lose the original position :)

![dmengine_BdSXQf4s78](https://github.com/user-attachments/assets/3ecaa71d-98a2-454c-874c-a61125259aac)
